### PR TITLE
proto3: Support optional field

### DIFF
--- a/protoc-c/c_field.cc
+++ b/protoc-c/c_field.cc
@@ -107,7 +107,7 @@ void FieldGenerator::GenerateDescriptorInitializerGeneric(io::Printer* printer,
 							  const std::string &descriptor_addr) const
 {
   std::map<std::string, std::string> variables;
-  const OneofDescriptor *oneof = descriptor_->containing_oneof();
+  const OneofDescriptor *oneof = descriptor_->real_containing_oneof();
   const ProtobufCFileOptions opt = descriptor_->file()->options().GetExtension(pb_c_file);
   variables["TYPE"] = type_macro;
   variables["classname"] = FullNameToC(FieldScope(descriptor_)->full_name(), FieldScope(descriptor_)->file());

--- a/protoc-c/c_generator.h
+++ b/protoc-c/c_generator.h
@@ -94,6 +94,11 @@ class PROTOC_C_EXPORT CGenerator : public CodeGenerator {
                 OutputDirectory* output_directory,
                 std::string* error) const;
 
+  uint64_t GetSupportedFeatures() const override {
+    // Indicate that this code generator supports proto3 optional fields.
+    return FEATURE_PROTO3_OPTIONAL;
+  }
+
  private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(CGenerator);
 };

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -149,7 +149,7 @@ GenerateStructDefinition(io::Printer* printer) {
   }
 
   // Generate the case enums for unions
-  for (int i = 0; i < descriptor_->oneof_decl_count(); i++) {
+  for (int i = 0; i < descriptor_->real_oneof_decl_count(); i++) {
     const OneofDescriptor *oneof = descriptor_->oneof_decl(i);
     vars["opt_comma"] = ",";
 
@@ -202,7 +202,7 @@ GenerateStructDefinition(io::Printer* printer) {
   }
 
   // Generate unions from oneofs.
-  for (int i = 0; i < descriptor_->oneof_decl_count(); i++) {
+  for (int i = 0; i < descriptor_->real_oneof_decl_count(); i++) {
     const OneofDescriptor *oneof = descriptor_->oneof_decl(i);
     vars["oneofname"] = CamelToLower(oneof->name());
     vars["foneofname"] = FullNameToC(oneof->full_name(), oneof->file());
@@ -238,12 +238,12 @@ GenerateStructDefinition(io::Printer* printer) {
 		       " { PROTOBUF_C_MESSAGE_INIT (&$lcclassname$__descriptor) \\\n    ");
   for (int i = 0; i < descriptor_->field_count(); i++) {
     const FieldDescriptor *field = descriptor_->field(i);
-    if (field->containing_oneof() == NULL) {
+    if (field->real_containing_oneof() == NULL) {
       printer->Print(", ");
       field_generators_.get(field).GenerateStaticInit(printer);
     }
   }
-  for (int i = 0; i < descriptor_->oneof_decl_count(); i++) {
+  for (int i = 0; i < descriptor_->real_oneof_decl_count(); i++) {
     const OneofDescriptor *oneof = descriptor_->oneof_decl(i);
     vars["foneofname"] = FullNameToUpper(oneof->full_name(), oneof->file());
     // Initialize the case enum

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -191,7 +191,7 @@ GenerateStructDefinition(io::Printer* printer) {
   printer->Indent();
   for (int i = 0; i < descriptor_->field_count(); i++) {
     const FieldDescriptor *field = descriptor_->field(i);
-    if (field->containing_oneof() == NULL) {
+    if (field->real_containing_oneof() == NULL) {
       SourceLocation fieldSourceLoc;
       field->GetSourceLocation(&fieldSourceLoc);
 


### PR DESCRIPTION
From proto3 migration guide, some modifications of protobuf code generators:

* To test whether a field is a member of a oneof: https://github.com/protocolbuffers/protobuf/blob/main/docs/implementing_proto3_presence.md#to-test-whether-a-field-is-a-member-of-a-oneof
* To iterate over all oneofs: https://github.com/protocolbuffers/protobuf/blob/main/docs/implementing_proto3_presence.md#to-iterate-over-all-oneofs

And also **To test whether a field should have presence** code should be changed but I didn't find where is checking the presence of a field presence in proto-c compiler.

This PR is based on https://github.com/protobuf-c/protobuf-c/issues/476 but added some additional changes for proto3 migration.